### PR TITLE
Update to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Declare your API's routes
 
 ```javascript
 // index.js
-const microApi = require('./index')
+const microApi = require('micro-api')
 const handlers = require('./handlers')
 
 const api = microApi([


### PR DESCRIPTION
The index.js was requiring in index.js rather than micro-api (as it would if it were downloaded via npm), which made the example confusing. I'm thinking this is what you were shooting for.